### PR TITLE
Set windows subsystem to windows

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![windows_subsystem = "windows"]
+
 mod decryption;
 mod error;
 mod save;


### PR DESCRIPTION
Currently, when launching Nine Saves, Windows automatically opens a console window. This is fixed by specifying the program is  under the "windows" [subsystem](https://learn.microsoft.com/en-us/cpp/build/reference/subsystem-specify-subsystem?view=msvc-170). 

Easy to fix with a crate attribute.